### PR TITLE
fix(features/homepage): fix image overflow on hover in FeaturedCategoriesItem

### DIFF
--- a/src/features/homepage/components/FeaturedCategories/FeaturedCategoriesItem/FeaturedCategoriesItem.module.scss
+++ b/src/features/homepage/components/FeaturedCategories/FeaturedCategoriesItem/FeaturedCategoriesItem.module.scss
@@ -2,6 +2,7 @@
 
 .featured-categories-item {
   position: relative;
+  overflow: hidden;
   &__img {
     display: block;
     width: 100%;
@@ -14,7 +15,7 @@
     }
 
     &:hover {
-      transform: scale(1.08);
+      transform: scale(1.1);
     }
   }
 

--- a/src/features/homepage/components/FeaturedCategories/FeaturedCategoriesList/FeaturedCategoriesList.module.scss
+++ b/src/features/homepage/components/FeaturedCategories/FeaturedCategoriesList/FeaturedCategoriesList.module.scss
@@ -1,7 +1,6 @@
 @use '../../../../../styles/variables' as *;
 
 .featured-categories-list {
-  overflow: hidden;
   display: grid;
   grid-template-columns: 100%;
   gap: $spacing-lg;


### PR DESCRIPTION
Fixed image overflow on hovering in Featured Categories Section

[featured-categories-hover.webm](https://github.com/user-attachments/assets/e702d0a7-b29d-415e-b61e-fbfde3909657)
